### PR TITLE
Migrate publish-docs to actions/deploy-pages (Node 24 ready)

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,11 +1,25 @@
 name: Publish docs to GitHub pages
+
 on:
   workflow_dispatch:
   push:
     branches:
       - main
+
+# Permissions are scoped per-job below. Defaults here are read-only so the
+# build job inherits least privilege; the deploy job opts in to pages:write
+# and id-token:write.
+permissions:
+  contents: read
+
+# Allow only one concurrent Pages deploy; don't cancel an in-progress one
+# (a cancelled mid-deploy can leave the site half-replaced).
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
-  publish-docs:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -14,12 +28,26 @@ jobs:
       - name: Build docs
         uses: ./.github/actions/build-docs-composite-action
 
-      # New step to copy CNAME into the ./docs directory
+      # GitHub Pages only serves the custom domain when CNAME is in the
+      # deployed tree.
       - name: Copy CNAME to docs
         run: cp CNAME ./docs/CNAME
 
-      - name: Publish docs
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs
+          path: ./docs
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write       # required to deploy
+      id-token: write    # required for OIDC verification of the artifact
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Final piece of the post-go-live cleanup chain. Retires the last Node 20 deprecation warning by switching from `peaceiris/actions-gh-pages` to GitHub's official Pages deploy flow.

## What changes

`publish-docs.yml` becomes a two-job workflow following the official template:

```
build  → actions/checkout@v5
        → composite (quarto render)
        → cp CNAME
        → actions/upload-pages-artifact@v3

deploy → actions/deploy-pages@v4   (needs: build)
```

Why two jobs:
- Build runs least-privilege (default permissions only).
- Deploy scopes `pages: write` and `id-token: write` (for the OIDC verification of the artifact) to itself, and binds to the `github-pages` environment so the deploy URL surfaces as a job output.
- Concurrency group `pages` with `cancel-in-progress: false` prevents a second push from killing an in-progress deploy mid-flight.

## Pre-merge action

GitHub Pages source must be switched from 'Deploy from a branch (gh-pages)' to 'GitHub Actions':

```
gh api -X PUT repos/Big-Life-Lab/popcorn-web/pages -F build_type=workflow
```

This is reversible (just switch it back) and seamless — Pages keeps serving the last `gh-pages` deployment until the first Actions-driven deploy completes, so there's no outage window.

## Verification plan

1. CI on this PR runs `check-pr` (which builds via the same composite action) — confirms the rendered output is unchanged.
2. Switch the Pages source via the API.
3. Merge. Watch the first Actions-driven deploy.
4. Verify the live site, then confirm the Node 20 deprecation warning is gone from the publish-docs log.

If anything fails: switch Pages source back to `branch=gh-pages` and revert this PR; the `gh-pages` branch still holds the last good build.

## Follow-up cleanup (separate)

The `gh-pages` branch is no longer used as the deploy target but is worth keeping for a few weeks as a rollback safety net. Can be deleted later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)